### PR TITLE
Fix read-write lock usage

### DIFF
--- a/src/SharedResourceReadWrite.java
+++ b/src/SharedResourceReadWrite.java
@@ -5,26 +5,27 @@ import static java.lang.System.out;
 public class SharedResourceReadWrite {
     public void producer(ReadWriteLock lock) {
         try {
-            lock.readLock().lock();
-            out.println("read lock acquired by: " + Thread.currentThread().getName());
-            Thread.sleep(3000);
-        } catch (Exception e) {
-            //
-        } finally {
-            out.println("read lock released by: " + Thread.currentThread().getName());
-            lock.readLock().unlock();
-        }
-    }
-    public void consumer(ReadWriteLock lock) {
-        try {
             lock.writeLock().lock();
             out.println("write lock acquired by: " + Thread.currentThread().getName());
-            Thread.sleep(6000);
+            Thread.sleep(3000);
         } catch (Exception e) {
             //
         } finally {
             out.println("write lock released by: " + Thread.currentThread().getName());
             lock.writeLock().unlock();
+        }
+    }
+
+    public void consumer(ReadWriteLock lock) {
+        try {
+            lock.readLock().lock();
+            out.println("read lock acquired by: " + Thread.currentThread().getName());
+            Thread.sleep(6000);
+        } catch (Exception e) {
+            //
+        } finally {
+            out.println("read lock released by: " + Thread.currentThread().getName());
+            lock.readLock().unlock();
         }
     }
 }


### PR DESCRIPTION
## Summary
- swap the lock types used in `SharedResourceReadWrite`

## Testing
- `javac src/*.java src/HumanResource/*.java src/SalesDepartment/*.java`

------
https://chatgpt.com/codex/tasks/task_e_685042635964832b891d19aa2f21aaf5